### PR TITLE
Fix for VNC disconnecting constantly.

### DIFF
--- a/roles/streamwall/templates/vnc@.service.j2
+++ b/roles/streamwall/templates/vnc@.service.j2
@@ -5,7 +5,7 @@ Requires=vnc.socket
 
 [Service]
 Type=simple
-ExecStart=x11vnc -inetd -passwd '{{ vnc_password }}'
+ExecStart=x11vnc -inetd -noxrecord -noxfixes -noxdamage -forever -bg -passwd '{{ vnc_password }}'
 StandardInput=socket
 StandardOutput=socket
 StandardError=journal


### PR DESCRIPTION
update to the vnc@.service.j2 ExecStart command to start x11vnc with additional options:

> -noxrecord : Workaround for x11 RECORD X extension bug
> -noxfixes : Workaround a crash in Xorg 1.5 and later
> -noxdamage : the DAMAGE extension is overly conservative and often reports large areas as damaged. It is only useful when the screen is not changing much which is never true for a streamwall
> -forever : possibly not needed but better safe than sorry. Remove this if it ends up causing problems as it stops the x11vnc process from shutting down.
> -bg : forking x11vnc stops it from sending errors to the client which can cause clients to crash.

